### PR TITLE
feat(js): update ICU 69 `trailingZeroDisplay` compat data

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -510,7 +510,7 @@
                 "description": "<code>options.trailingZeroDisplay</code> parameter",
                 "support": {
                   "chrome": {
-                    "version_added": false
+                    "version_added": "106"
                   },
                   "chrome_android": "mirror",
                   "deno": {
@@ -527,7 +527,9 @@
                   "nodejs": {
                     "version_added": false
                   },
-                  "opera": "mirror",
+                  "opera": {
+                    "version_added": false
+                  },
                   "opera_android": "mirror",
                   "safari": {
                     "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chromium 106 and WebKit 15.6 (?) adds support for the `options.trailingZeroDisplay` parameter in `Intl.NumberFormat()`.

#### Test results and supporting details

**Chromium ref:** https://bugs.chromium.org/p/v8/issues/detail?id=12550

**Webkit: ??**

Unable to find supporting details that this has left experimental on WebKit. https://bugs.webkit.org/show_bug.cgi?id=215438 is still open. But it seems to work in the following versions of Safari:

Tested on Safari|Works
--|--
16|✅
15.6|✅
14.1|❌

I currently don't have a way to test the versions between 14.1 and 15.6. Perhaps someone with more info can chip in.

#### Related issues

N/A